### PR TITLE
Run against the img data directory directly

### DIFF
--- a/src/s2cloudless_optimized/__init__.py
+++ b/src/s2cloudless_optimized/__init__.py
@@ -6,6 +6,7 @@ from .granule import Granule, OutputPaths
 
 def run(
     directory: str,
+    directory_is_granule: Optional[bool] = True,
     resolution: Optional[Union[float, HighLow]] = None,
     output_directory: Optional[str] = None,
 ) -> OutputPaths:
@@ -15,5 +16,8 @@ def run(
 
     Returns the resultant paths.
     """
-    granule = Granule(directory)
+    if directory_is_granule:
+        granule = Granule.from_granule_path(directory)
+    else:
+        granule = Granule(directory)
     return granule.run(resolution, output_directory=output_directory)

--- a/src/s2cloudless_optimized/granule.py
+++ b/src/s2cloudless_optimized/granule.py
@@ -39,23 +39,28 @@ class Granule:
     """A dictionary of band -> path"""
     paths: Dict[str, str]
 
-    def __init__(self, directory: str):
-        """Creates from a directory containing IMG_DATA"""
-        img_directory = os.path.join(directory, "IMG_DATA")
-        if not os.path.isdir(img_directory):
+    @classmethod
+    def from_granule_path(cls, directory: str) -> "Granule":
+        """Creates a granule from a directory containing `IMG_DATA`."""
+        img_data_directory = os.path.join(directory, "IMG_DATA")
+        if not os.path.isdir(img_data_directory):
             raise ValueError(
                 f"{directory} is not a sentinel2 granule, does not contain an 'IMG_DATA' directory"
             )
+        return cls(img_data_directory)
+
+    def __init__(self, directory: str):
+        """Creates from a directory containing jp2 images."""
         self.paths = dict()
         bands = set()
-        for file_name in os.listdir(img_directory):
+        for file_name in os.listdir(directory):
             basename, ext = os.path.splitext(file_name)
             if ext != ".jp2":
                 continue
             parts = basename.split("_")
             band = parts[-1]
             if band in BANDS:
-                self.paths[band] = os.path.join(img_directory, file_name)
+                self.paths[band] = os.path.join(directory, file_name)
                 bands.add(band)
         if len(self.paths) != len(BANDS):
             missing_bands = set(BANDS) - bands

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,8 +1,17 @@
+import os.path
 from tempfile import TemporaryDirectory
 
 import rasterio
 
 import s2cloudless_optimized
+from s2cloudless_optimized.granule import OutputPaths
+
+
+def assert_output_paths_ok(output_paths: OutputPaths):
+    for path in [output_paths.probabilities, output_paths.cloud_mask]:
+        with rasterio.open(path) as dataset:
+            assert dataset.profile["dtype"] == "uint8"
+            assert dataset.profile["driver"] == "GTiff"
 
 
 def test_run(granule_directory):
@@ -10,7 +19,15 @@ def test_run(granule_directory):
         output_paths = s2cloudless_optimized.run(
             granule_directory, output_directory=temporary_directory
         )
-        for path in [output_paths.probabilities, output_paths.cloud_mask]:
-            with rasterio.open(path) as dataset:
-                assert dataset.profile["dtype"] == "uint8"
-                assert dataset.profile["driver"] == "GTiff"
+        assert_output_paths_ok(output_paths)
+
+
+def test_run_with_exact_directory(granule_directory):
+    img_data_directory = os.path.join(granule_directory, "IMG_DATA")
+    with TemporaryDirectory() as temporary_directory:
+        output_paths = s2cloudless_optimized.run(
+            img_data_directory,
+            directory_is_granule=False,
+            output_directory=temporary_directory,
+        )
+        assert_output_paths_ok(output_paths)


### PR DESCRIPTION
This enables usage for non-complete granules, e.g. when the images have been downloaded to a temporary directory.